### PR TITLE
Narrative Voice Overhaul: Post-Glitch Compliance

### DIFF
--- a/.jules/narrator.md
+++ b/.jules/narrator.md
@@ -1,0 +1,14 @@
+## 2024-05-22 - Post-Glitch Vocabulary Audit
+**Challenge:** "Electricity" / "Power" / "Radiation"
+**Translation:** "Invisible Fire" / "The Anger of Storms" / "Blight-Heat"
+**Why:** Replaced technical terms with ritualistic/animistic metaphors to enforce the "Ignorance is Aesthetic" pillar. Electricity is now treated as a dangerous spirit-force rather than a physical phenomenon.
+
+## 2024-05-22 - Entity Renaming
+**Challenge:** "Robot" / "Drone" / "Bot"
+**Translation:** "Iron-Walker" / "Spirit" / "Construct"
+**Why:** "Robot" implies manufactured servitude. "Iron-Walker" implies a creature made of metal. "Drone" is too modern; "Spirit" or "Hawk" fits the animistic worldview.
+
+## 2024-05-22 - Hazard Description Overhaul
+**Challenge:** "Magical Darkness" / "Necrotic Energy"
+**Translation:** "Unnatural Shadow" / "Shadow-Sickness"
+**Why:** "Magical" is a L1 term that should be rare. "Unnatural" fits the L2 diagnostic/observation layer better while maintaining the mystery. "Necrotic Energy" is too D&D; "Shadow-Sickness" is more visceral.

--- a/src/Core/RuneAndRust.Application/Interfaces/IInputHandler.cs
+++ b/src/Core/RuneAndRust.Application/Interfaces/IInputHandler.cs
@@ -27,7 +27,6 @@ public record TakeCommand(string ItemName) : GameCommand;
 public record AttackCommand : GameCommand;
 public record SearchCommand(string? Target = null) : GameCommand;
 public record InvestigateCommand(string Target) : GameCommand;
-public record ExamineCommand(string Target) : GameCommand;
 public record TravelCommand(string? Destination = null) : GameCommand;
 public record EnterCommand(string? Location = null) : GameCommand;
 public record ExitCommand(string? Direction = null) : GameCommand;

--- a/src/Core/RuneAndRust.Domain/Entities/GameSession.cs
+++ b/src/Core/RuneAndRust.Domain/Entities/GameSession.cs
@@ -34,9 +34,19 @@ public class GameSession : IEntity
     public Guid CurrentRoomId { get; private set; }
 
     /// <summary>
+    /// Gets the ID of the previous room the player was in.
+    /// </summary>
+    public Guid? PreviousRoomId { get; private set; }
+
+    /// <summary>
     /// Gets the current state of the game (e.g., Playing, GameOver, Victory).
     /// </summary>
     public GameState State { get; private set; }
+
+    /// <summary>
+    /// Gets the number of turns elapsed in the current session.
+    /// </summary>
+    public int TurnCount { get; private set; }
 
     /// <summary>
     /// Gets the UTC timestamp when this session was created.
@@ -48,6 +58,7 @@ public class GameSession : IEntity
     /// </summary>
     public DateTime LastPlayedAt { get; private set; }
 
+    private readonly HashSet<Guid> _visitedRooms = [];
     private readonly HashSet<string> _revealedSolutionIds = [];
 
     public Room? CurrentRoom => Dungeon.GetRoom(CurrentRoomId);
@@ -183,6 +194,15 @@ public class GameSession : IEntity
     public void UpdateLastPlayed()
     {
         LastPlayedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Advances the game turn count.
+    /// </summary>
+    public void AdvanceTurn()
+    {
+        TurnCount++;
+        UpdateLastPlayed();
     }
 
     /// <summary>

--- a/src/Core/RuneAndRust.Domain/Entities/HazardZone.cs
+++ b/src/Core/RuneAndRust.Domain/Entities/HazardZone.cs
@@ -284,16 +284,16 @@ public class HazardZone : IEntity
     /// <returns>A descriptive string for the hazard type.</returns>
     public string GetHazardTypeDescription() => HazardType switch
     {
-        HazardType.PoisonGas => "Poisonous gas fills the area",
-        HazardType.Fire => "Flames burn throughout the area",
-        HazardType.Ice => "Bitter cold permeates the area",
-        HazardType.Spikes => "Sharp spikes cover the ground",
-        HazardType.AcidPool => "Corrosive acid pools on the floor",
-        HazardType.Darkness => "Magical darkness obscures vision",
-        HazardType.Electricity => "Electrical energy crackles through the air",
-        HazardType.Radiant => "Radiant energy fills the area",
-        HazardType.Necrotic => "Necrotic energy drains life force",
-        _ => "An unknown hazard affects this area"
+        HazardType.PoisonGas => "Choking fumes cling to the air",
+        HazardType.Fire => "Unsleeping fire hungers here",
+        HazardType.Ice => "The air bites with the cold of the grave",
+        HazardType.Spikes => "The ground is teeth and jagged iron",
+        HazardType.AcidPool => "Pools of biting water scar the floor",
+        HazardType.Darkness => "Shadows thick enough to drown in",
+        HazardType.Electricity => "The anger of storms crackles unseen",
+        HazardType.Radiant => "A burning light scours the shadows",
+        HazardType.Necrotic => "The air itself tastes of ash and endings",
+        _ => "The area feels wrong, though the reason is hidden"
     };
 
     /// <summary>

--- a/src/Core/RuneAndRust.Domain/Entities/Room.cs
+++ b/src/Core/RuneAndRust.Domain/Entities/Room.cs
@@ -28,7 +28,6 @@ public class Room : IEntity
     /// Gets the narrative description of this room shown to the player.
     /// </summary>
     public string Description { get; private set; }
-    public Position Position { get; private set; }
     public Biome Biome { get; private set; }
 
     /// <summary>
@@ -354,7 +353,7 @@ public class Room : IEntity
         Description = null!;
     }
 
-    public Room(string name, string description, Position position, Biome biome = Biome.Citadel)
+    public Room(string name, string description, Position3D position, Biome biome = Biome.Citadel)
     {
         Id = Guid.NewGuid();
         Name = name ?? throw new ArgumentNullException(nameof(name));
@@ -371,8 +370,8 @@ public class Room : IEntity
     /// that uses 2D positions. The Z coordinate defaults to 0 (surface level).
     /// </remarks>
     [Obsolete("Use the Position3D constructor for new code. This exists for backwards compatibility.")]
-    public Room(string name, string description, Position position)
-        : this(name, description, Position3D.FromPosition2D(position))
+    public Room(string name, string description, Position position, Biome biome = Biome.Citadel)
+        : this(name, description, Position3D.FromPosition2D(position), biome)
     {
     }
 

--- a/src/Core/RuneAndRust.Domain/Enums/HazardType.cs
+++ b/src/Core/RuneAndRust.Domain/Enums/HazardType.cs
@@ -8,15 +8,15 @@ namespace RuneAndRust.Domain.Enums;
 /// who remain in or pass through affected areas. Each type has distinct
 /// visual and mechanical characteristics that affect gameplay:
 /// <list type="bullet">
-///   <item><description><see cref="PoisonGas"/> - Toxic clouds that poison on failed saves</description></item>
-///   <item><description><see cref="Fire"/> - Flames that burn with fire damage</description></item>
-///   <item><description><see cref="Ice"/> - Extreme cold that slows movement</description></item>
-///   <item><description><see cref="Spikes"/> - Physical hazards dealing piercing damage</description></item>
-///   <item><description><see cref="AcidPool"/> - Corrosive pools that damage equipment</description></item>
-///   <item><description><see cref="Darkness"/> - Magical darkness affecting visibility (no damage)</description></item>
-///   <item><description><see cref="Electricity"/> - Electrical fields that shock</description></item>
-///   <item><description><see cref="Radiant"/> - Holy energy effective against undead</description></item>
-///   <item><description><see cref="Necrotic"/> - Life-draining dark energy</description></item>
+///   <item><description><see cref="PoisonGas"/> - Choking fumes that sicken the body</description></item>
+///   <item><description><see cref="Fire"/> - Unsleeping fire that hungers</description></item>
+///   <item><description><see cref="Ice"/> - The grave-cold that slows movement</description></item>
+///   <item><description><see cref="Spikes"/> - Teeth of iron and stone</description></item>
+///   <item><description><see cref="AcidPool"/> - Biting water that eats metal</description></item>
+///   <item><description><see cref="Darkness"/> - Shadows thick enough to drown in</description></item>
+///   <item><description><see cref="Electricity"/> - The anger of storms made manifest</description></item>
+///   <item><description><see cref="Radiant"/> - Sun-fire that scours the shadows</description></item>
+///   <item><description><see cref="Necrotic"/> - Shadow-sickness that drains the spirit</description></item>
 /// </list>
 /// </remarks>
 /// <seealso cref="RuneAndRust.Domain.Entities.HazardZone"/>
@@ -47,31 +47,31 @@ public enum HazardType
     Spikes = 3,
 
     /// <summary>
-    /// Corrosive acid that damages and corrodes equipment.
+    /// Biting water that eats through metal and flesh.
     /// Deals acid damage and may damage armor or weapons over time.
     /// </summary>
     AcidPool = 4,
 
     /// <summary>
-    /// Magical darkness that obscures vision.
+    /// Unnatural shadow that drowns all light.
     /// Does not deal damage but imposes penalties to perception and attacks.
     /// </summary>
     Darkness = 5,
 
     /// <summary>
-    /// Electrical energy that shocks creatures within.
+    /// The invisible fire of storms.
     /// Deals lightning damage and may cause paralysis on critical failures.
     /// </summary>
     Electricity = 6,
 
     /// <summary>
-    /// Holy or radiant energy.
+    /// Sun-fire or star-light.
     /// Deals radiant damage, particularly effective against undead creatures.
     /// </summary>
     Radiant = 7,
 
     /// <summary>
-    /// Necrotic energy that drains life force.
+    /// Shadow-sickness that drains the spirit.
     /// Deals necrotic damage and may reduce maximum health temporarily.
     /// </summary>
     Necrotic = 8,

--- a/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/DescriptorFragmentSeeder.cs
+++ b/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/DescriptorFragmentSeeder.cs
@@ -420,7 +420,7 @@ public static class DescriptorFragmentSeeder
             weight: 2);
 
         yield return DescriptorFragment.CreateAtmospheric(
-            "tinged with ozone and electricity",
+            "tinged with the bitter scent of lightning",
             AtmosphericSubcategory.Smell,
             weight: 2);
 
@@ -560,7 +560,7 @@ public static class DescriptorFragmentSeeder
             weight: 2);
 
         yield return DescriptorFragment.CreateAtmospheric(
-            "An electrical buzz fills the air",
+            "The hum of sleeping thunder fills the air",
             AtmosphericSubcategory.Sound,
             weight: 2);
 
@@ -675,7 +675,7 @@ public static class DescriptorFragmentSeeder
             weight: 1);
 
         yield return DescriptorFragment.CreateAtmospheric(
-            "Sparks of static electricity dance in the shadows",
+            "Ghost-sparks dance in the shadows",
             AtmosphericSubcategory.Light,
             biomeAffinity: Biome.Surface,
             weight: 2);

--- a/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/EntityTableSeeder.cs
+++ b/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/EntityTableSeeder.cs
@@ -46,46 +46,46 @@ public static class EntityTableSeeder
 
         // Swarm units (cost 1-5)
         var skeleton = EntityTemplate.CreateSwarm(
-            "skeleton_minion", "Skeleton Minion", factionId, Biome.Citadel,
+            "skeleton_minion", "Bone-Thrall", factionId, Biome.Citadel,
             cost: 3, new Stats(15, 5, 2, 5));
         skeleton.AddTags(["Undead", "Brittle", "Melee"]);
         yield return skeleton;
 
         var ghostLight = EntityTemplate.CreateSwarm(
-            "ghost_light", "Ghost Light", factionId, Biome.Citadel,
+            "ghost_light", "Spirit-Wisp", factionId, Biome.Citadel,
             cost: 2, new Stats(8, 3, 0, 8));
         ghostLight.AddTags(["Undead", "Flying", "Glowing"]);
         yield return ghostLight;
 
         // Grunt units (cost 5-40)
         var skeletonWarrior = EntityTemplate.CreateGrunt(
-            "skeleton_warrior", "Skeleton Warrior", factionId, Biome.Citadel,
+            "skeleton_warrior", "Bone-Guard", factionId, Biome.Citadel,
             cost: 10, EntityRole.Melee, new Stats(30, 10, 5, 6));
         skeletonWarrior.AddTags(["Undead", "Armed", "Melee"]);
         yield return skeletonWarrior;
 
         var skeletonArcher = EntityTemplate.CreateGrunt(
-            "skeleton_archer", "Skeleton Archer", factionId, Biome.Citadel,
+            "skeleton_archer", "Bone-Bow", factionId, Biome.Citadel,
             cost: 12, EntityRole.Ranged, new Stats(20, 12, 3, 8));
         skeletonArcher.AddTags(["Undead", "Armed", "Ranged"]);
         yield return skeletonArcher;
 
         var wight = EntityTemplate.CreateGrunt(
-            "wight", "Barrow Wight", factionId, Biome.Citadel,
+            "wight", "Grave-Wight", factionId, Biome.Citadel,
             cost: 25, EntityRole.Tank, new Stats(50, 12, 10, 10));
         wight.AddTags(["Undead", "Heavy", "Fearsome"]);
         yield return wight;
 
         // Elite unit (cost 40+)
         var deathKnight = EntityTemplate.CreateElite(
-            "death_knight", "Death Knight", factionId, Biome.Citadel,
+            "death_knight", "Iron-Bound Captain", factionId, Biome.Citadel,
             cost: 60, new Stats(80, 18, 15, 12));
         deathKnight.AddTags(["Undead", "Heavy", "Melee", "Commander"]);
         yield return deathKnight;
 
         // Boss unit (cost 100+)
         var lichLord = EntityTemplate.CreateBoss(
-            "lich_lord", "Lich Lord", factionId, Biome.Citadel,
+            "lich_lord", "Dead-King", factionId, Biome.Citadel,
             cost: 150, new Stats(120, 25, 12, 18));
         lichLord.AddTags(["Undead", "Magical", "Ranged", "Commander"]);
         yield return lichLord;
@@ -101,46 +101,46 @@ public static class EntityTableSeeder
 
         // Swarm units
         var rustMite = EntityTemplate.CreateSwarm(
-            "rust_mite", "Rust Mite", factionId, Biome.TheRoots,
+            "rust_mite", "Iron-Louse", factionId, Biome.TheRoots,
             cost: 2, new Stats(10, 4, 1, 4));
         rustMite.AddTags(["Mechanical", "Swarm", "Corrosive"]);
         yield return rustMite;
 
         var sporeCloud = EntityTemplate.CreateSwarm(
-            "spore_cloud", "Spore Cloud", factionId, Biome.TheRoots,
+            "spore_cloud", "Rot-Mist", factionId, Biome.TheRoots,
             cost: 3, new Stats(12, 3, 0, 6));
         sporeCloud.AddTags(["Organic", "Flying", "Toxic"]);
         yield return sporeCloud;
 
         // Grunt units
         var scavengerDrone = EntityTemplate.CreateGrunt(
-            "scavenger_drone", "Scavenger Drone", factionId, Biome.TheRoots,
+            "scavenger_drone", "Scrap-Hawk", factionId, Biome.TheRoots,
             cost: 15, EntityRole.Melee, new Stats(35, 12, 6, 8));
         scavengerDrone.AddTags(["Mechanical", "Salvager", "Melee"]);
         yield return scavengerDrone;
 
         var fungalStalker = EntityTemplate.CreateGrunt(
-            "fungal_stalker", "Fungal Stalker", factionId, Biome.TheRoots,
+            "fungal_stalker", "Mold-Walker", factionId, Biome.TheRoots,
             cost: 18, EntityRole.Melee, new Stats(40, 14, 5, 12));
         fungalStalker.AddTags(["Organic", "Stealthy", "Melee"]);
         yield return fungalStalker;
 
         var spitterNode = EntityTemplate.CreateGrunt(
-            "spitter_node", "Spitter Node", factionId, Biome.TheRoots,
+            "spitter_node", "Blight-Gland", factionId, Biome.TheRoots,
             cost: 20, EntityRole.Ranged, new Stats(30, 15, 4, 6));
         spitterNode.AddTags(["Organic", "Stationary", "Ranged", "Toxic"]);
         yield return spitterNode;
 
         // Elite unit
         var heavyLoader = EntityTemplate.CreateElite(
-            "heavy_loader", "Heavy Loader Bot", factionId, Biome.TheRoots,
+            "heavy_loader", "Titan-Lifter", factionId, Biome.TheRoots,
             cost: 55, new Stats(90, 20, 18, 6));
         heavyLoader.AddTags(["Mechanical", "Heavy", "Melee", "Armored"]);
         yield return heavyLoader;
 
         // Boss unit
         var rootMother = EntityTemplate.CreateBoss(
-            "root_mother", "The Root Mother", factionId, Biome.TheRoots,
+            "root_mother", "The Rot-Mother", factionId, Biome.TheRoots,
             cost: 140, new Stats(150, 22, 15, 14));
         rootMother.AddTags(["Organic", "Massive", "Spawner", "Commander"]);
         yield return rootMother;
@@ -156,46 +156,46 @@ public static class EntityTableSeeder
 
         // Swarm units
         var fireImp = EntityTemplate.CreateSwarm(
-            "fire_imp", "Fire Imp", factionId, Biome.Muspelheim,
+            "fire_imp", "Spark-Imp", factionId, Biome.Muspelheim,
             cost: 4, new Stats(12, 6, 2, 10));
         fireImp.AddTags(["Fire", "Small", "Ranged"]);
         yield return fireImp;
 
         var cinder = EntityTemplate.CreateSwarm(
-            "cinder", "Living Cinder", factionId, Biome.Muspelheim,
+            "cinder", "Ember-Mote", factionId, Biome.Muspelheim,
             cost: 3, new Stats(8, 5, 0, 8));
         cinder.AddTags(["Fire", "Flying", "Explosive"]);
         yield return cinder;
 
         // Grunt units
         var flameCultist = EntityTemplate.CreateGrunt(
-            "flame_cultist", "Flame Cultist", factionId, Biome.Muspelheim,
+            "flame_cultist", "Ash-Touched", factionId, Biome.Muspelheim,
             cost: 12, EntityRole.Ranged, new Stats(25, 12, 4, 10));
         flameCultist.AddTags(["Human", "Fire", "Ranged"]);
         yield return flameCultist;
 
         var magmaElemental = EntityTemplate.CreateGrunt(
-            "magma_elemental", "Magma Elemental", factionId, Biome.Muspelheim,
+            "magma_elemental", "Molten-Walk", factionId, Biome.Muspelheim,
             cost: 30, EntityRole.Tank, new Stats(60, 15, 12, 6));
         magmaElemental.AddTags(["Elemental", "Fire", "Heavy", "Melee"]);
         yield return magmaElemental;
 
         var ashWraith = EntityTemplate.CreateGrunt(
-            "ash_wraith", "Ash Wraith", factionId, Biome.Muspelheim,
+            "ash_wraith", "Cinder-Ghost", factionId, Biome.Muspelheim,
             cost: 22, EntityRole.Melee, new Stats(40, 16, 6, 12));
         ashWraith.AddTags(["Undead", "Fire", "Phasing", "Melee"]);
         yield return ashWraith;
 
         // Elite unit
         var flameWarden = EntityTemplate.CreateElite(
-            "flame_warden", "Flame Warden", factionId, Biome.Muspelheim,
+            "flame_warden", "Pyre-Keeper", factionId, Biome.Muspelheim,
             cost: 65, new Stats(85, 22, 14, 14));
         flameWarden.AddTags(["Human", "Fire", "Heavy", "Melee", "Commander"]);
         yield return flameWarden;
 
         // Boss unit
         var emberKing = EntityTemplate.CreateBoss(
-            "ember_king", "The Ember King", factionId, Biome.Muspelheim,
+            "ember_king", "Lord of Cinders", factionId, Biome.Muspelheim,
             cost: 160, new Stats(140, 28, 18, 16));
         emberKing.AddTags(["Elemental", "Fire", "Massive", "Ranged", "Commander"]);
         yield return emberKing;
@@ -211,46 +211,46 @@ public static class EntityTableSeeder
 
         // Swarm units
         var iceSprite = EntityTemplate.CreateSwarm(
-            "ice_sprite", "Ice Sprite", factionId, Biome.Niflheim,
+            "ice_sprite", "Frost-Needle", factionId, Biome.Niflheim,
             cost: 3, new Stats(10, 4, 1, 12));
         iceSprite.AddTags(["Cold", "Small", "Flying", "Freezing"]);
         yield return iceSprite;
 
         var frostWorm = EntityTemplate.CreateSwarm(
-            "frost_worm", "Frost Worm", factionId, Biome.Niflheim,
+            "frost_worm", "Ice-Wyrm", factionId, Biome.Niflheim,
             cost: 4, new Stats(15, 5, 3, 4));
         frostWorm.AddTags(["Cold", "Burrowing", "Melee"]);
         yield return frostWorm;
 
         // Grunt units
         var frozenCorpse = EntityTemplate.CreateGrunt(
-            "frozen_corpse", "Frozen Corpse", factionId, Biome.Niflheim,
+            "frozen_corpse", "Rime-Husk", factionId, Biome.Niflheim,
             cost: 14, EntityRole.Melee, new Stats(35, 10, 8, 5));
         frozenCorpse.AddTags(["Undead", "Cold", "Slow", "Melee"]);
         yield return frozenCorpse;
 
         var iceWraith = EntityTemplate.CreateGrunt(
-            "ice_wraith", "Ice Wraith", factionId, Biome.Niflheim,
+            "ice_wraith", "Winter-Ghost", factionId, Biome.Niflheim,
             cost: 20, EntityRole.Melee, new Stats(30, 14, 4, 14));
         iceWraith.AddTags(["Undead", "Cold", "Phasing", "Melee", "Freezing"]);
         yield return iceWraith;
 
         var frostArcher = EntityTemplate.CreateGrunt(
-            "frost_archer", "Frost Archer", factionId, Biome.Niflheim,
+            "frost_archer", "Chill-Bow", factionId, Biome.Niflheim,
             cost: 16, EntityRole.Ranged, new Stats(25, 13, 5, 10));
         frostArcher.AddTags(["Human", "Cold", "Ranged", "Freezing"]);
         yield return frostArcher;
 
         // Elite unit
         var glacialBehemoth = EntityTemplate.CreateElite(
-            "glacial_behemoth", "Glacial Behemoth", factionId, Biome.Niflheim,
+            "glacial_behemoth", "Mountain-Shaker", factionId, Biome.Niflheim,
             cost: 70, new Stats(100, 18, 20, 6));
         glacialBehemoth.AddTags(["Elemental", "Cold", "Massive", "Melee", "Armored"]);
         yield return glacialBehemoth;
 
         // Boss unit
         var frostQueen = EntityTemplate.CreateBoss(
-            "frost_queen", "The Frost Queen", factionId, Biome.Niflheim,
+            "frost_queen", "Lady of Winter", factionId, Biome.Niflheim,
             cost: 155, new Stats(130, 24, 16, 18));
         frostQueen.AddTags(["Undead", "Cold", "Magical", "Ranged", "Commander"]);
         yield return frostQueen;
@@ -266,46 +266,46 @@ public static class EntityTableSeeder
 
         // Swarm units
         var stoneSprite = EntityTemplate.CreateSwarm(
-            "stone_sprite", "Stone Sprite", factionId, Biome.Jotunheim,
+            "stone_sprite", "Pebble-Kin", factionId, Biome.Jotunheim,
             cost: 4, new Stats(18, 5, 5, 6));
         stoneSprite.AddTags(["Elemental", "Stone", "Small"]);
         yield return stoneSprite;
 
         var runeWisp = EntityTemplate.CreateSwarm(
-            "rune_wisp", "Rune Wisp", factionId, Biome.Jotunheim,
+            "rune_wisp", "Glyph-Light", factionId, Biome.Jotunheim,
             cost: 5, new Stats(12, 7, 0, 14));
         runeWisp.AddTags(["Magical", "Flying", "Ranged"]);
         yield return runeWisp;
 
         // Grunt units
         var giantkin = EntityTemplate.CreateGrunt(
-            "giantkin", "Giantkin Warrior", factionId, Biome.Jotunheim,
+            "giantkin", "Titan-Blood", factionId, Biome.Jotunheim,
             cost: 25, EntityRole.Melee, new Stats(55, 16, 10, 8));
         giantkin.AddTags(["Giant", "Heavy", "Melee"]);
         yield return giantkin;
 
         var runeguard = EntityTemplate.CreateGrunt(
-            "runeguard", "Rune Guardian", factionId, Biome.Jotunheim,
+            "runeguard", "Glyph-Sentinel", factionId, Biome.Jotunheim,
             cost: 30, EntityRole.Tank, new Stats(70, 12, 15, 10));
         runeguard.AddTags(["Construct", "Magical", "Armored", "Melee"]);
         yield return runeguard;
 
         var stormcaller = EntityTemplate.CreateGrunt(
-            "stormcaller", "Storm Caller", factionId, Biome.Jotunheim,
+            "stormcaller", "Thunder-Voice", factionId, Biome.Jotunheim,
             cost: 28, EntityRole.Ranged, new Stats(40, 18, 6, 14));
         stormcaller.AddTags(["Giant", "Magical", "Ranged", "Lightning"]);
         yield return stormcaller;
 
         // Elite unit
         var jotunChampion = EntityTemplate.CreateElite(
-            "jotun_champion", "Jotun Champion", factionId, Biome.Jotunheim,
+            "jotun_champion", "High-Kin", factionId, Biome.Jotunheim,
             cost: 80, new Stats(120, 24, 18, 10));
         jotunChampion.AddTags(["Giant", "Heavy", "Melee", "Commander"]);
         yield return jotunChampion;
 
         // Boss unit
         var titanAwakened = EntityTemplate.CreateBoss(
-            "titan_awakened", "Awakened Titan", factionId, Biome.Jotunheim,
+            "titan_awakened", "Mountain-Walker", factionId, Biome.Jotunheim,
             cost: 200, new Stats(200, 35, 25, 12));
         titanAwakened.AddTags(["Giant", "Massive", "Ancient", "Commander"]);
         yield return titanAwakened;

--- a/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/InteractionDescriptorSeeder.cs
+++ b/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/InteractionDescriptorSeeder.cs
@@ -77,7 +77,7 @@ public static class InteractionDescriptorSeeder
         // Terminals (Oracle-Boxes)
         yield return new InteractionDescriptor(NextId(),
             InteractionCategory.MechanicalObject, "Terminal", "Active",
-            "The oracle-box hums with power, glass face swimming with ghost-light");
+            "The oracle-box hums with invisible fire, glass face swimming with ghost-light");
 
         yield return new InteractionDescriptor(NextId(),
             InteractionCategory.MechanicalObject, "Terminal", "Dormant",
@@ -434,7 +434,7 @@ public static class InteractionDescriptorSeeder
 
         yield return new InteractionDescriptor(NextId(),
             InteractionCategory.SkillSpecific, "Trade", "Runeforging",
-            "The inscriptions are degraded but readable. Power remains here");
+            "The inscriptions are degraded but readable. The old strength remains here");
 
         yield return new InteractionDescriptor(NextId(),
             InteractionCategory.SkillSpecific, "Trade", "Runeforging2",
@@ -447,7 +447,7 @@ public static class InteractionDescriptorSeeder
 
         yield return new InteractionDescriptor(NextId(),
             InteractionCategory.SkillSpecific, "Specialization", "JotunReader2",
-            "This is Giant-tech. Original. Unmolested since the Glitch");
+            "This is Giant-craft. Original. Unmolested since the Glitch");
 
         yield return new InteractionDescriptor(NextId(),
             InteractionCategory.SkillSpecific, "Specialization", "RuinStalker",

--- a/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/RoomFunctionSeeder.cs
+++ b/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/RoomFunctionSeeder.cs
@@ -13,26 +13,26 @@ public static class RoomFunctionSeeder
     {
         // Utility/Infrastructure functions
         yield return new RoomFunction(
-            "Pumping Station",
-            "Massive geothermal pumps once circulated superheated fluids through the facility. Now they groan with neglect, leaking scalding steam from corroded seals.",
+            "Breath-Engine",
+            "Massive earth-lungs once breathed fire-water through the veins of the world. Now they groan with the sickness of age, weeping scalding steam from rusted wounds.",
             [Biome.TheRoots, Biome.Muspelheim],
             weight: 2);
 
         yield return new RoomFunction(
-            "Power Station",
-            "Banks of capacitors and generators line the walls, some still humming with residual charge. Cables snake across the floor like mechanical tendrils.",
+            "Thunder-Mill",
+            "Banks of lightning-jars and spark-mills line the walls, some still humming with the memory of the storm. Copper-vines snake across the floor.",
             [Biome.TheRoots, Biome.Citadel],
             weight: 2);
 
         yield return new RoomFunction(
-            "Water Treatment",
-            "Massive filtration tanks dominate the space, filled with murky liquid. The air is thick with chemical odors and the sound of dripping.",
+            "Purification Sanctum",
+            "Great cisterns dominate the space, filled with dead water. The air is thick with the scent of poison and the sound of weeping stone.",
             [Biome.TheRoots],
             weight: 1);
 
         yield return new RoomFunction(
-            "Ventilation Hub",
-            "Giant fans hang motionless from the ceiling, their blades casting strange shadows. Air shafts lead off in multiple directions.",
+            "Wind-Hall",
+            "Great wind-blades hang motionless from the ceiling, their iron wings casting strange shadows. Breath-tunnels lead off in multiple directions.",
             [Biome.TheRoots, Biome.Citadel],
             weight: 2);
 
@@ -127,8 +127,8 @@ public static class RoomFunctionSeeder
 
         // Specialized biome functions
         yield return new RoomFunction(
-            "Reactor Core",
-            "The heart of the facility's power generation. Containment fields flicker weakly around an energy source that defies understanding.",
+            "Sun-Heart Chamber",
+            "The heart of the Sun-Mill. Ghost-walls flicker weakly around a burning star-shard that defies the eye.",
             [Biome.Muspelheim, Biome.Alfheim],
             weight: 1);
 
@@ -145,8 +145,8 @@ public static class RoomFunctionSeeder
             weight: 1);
 
         yield return new RoomFunction(
-            "Runic Chamber",
-            "Ancient runes cover every surface, pulsing with a power that predates recorded history. Their meaning is lost, but their power remains.",
+            "Glyph-Sanctum",
+            "Ancient glyphs scar every surface, pulsing with the old blood. Their meaning is lost, but their hunger remains.",
             [Biome.Jotunheim, Biome.Alfheim],
             weight: 1);
     }


### PR DESCRIPTION
This PR implements the "Narrator" agent's directive to enforce a "Post-Glitch" aesthetic across all descriptive content. It replaces technical terms with ritualistic/animistic metaphors (e.g., "Electricity" -> "Invisible Fire", "Robot" -> "Iron-Walker") in seeders and entity definitions.

It also includes necessary fixes to `Room.cs`, `GameSession.cs`, and `IInputHandler.cs` to resolve pre-existing build errors and allow verification of the narrative changes. Note that some build errors persist in `TemplateValidationService` due to deeper issues with `RoomTemplate` definition which are out of scope for this narrative overhaul.

---
*PR created automatically by Jules for task [12275078672969693394](https://jules.google.com/task/12275078672969693394) started by @southpawriter02*