### PR TITLE
Implement Narrator Agent and Post-Glitch Descriptions

### DIFF
--- a/.jules/narrator.md
+++ b/.jules/narrator.md
@@ -1,0 +1,6 @@
+# The Narrator's Journal
+
+## 2024-05-22 - Journal Initialized
+**Challenge:** Establishing the voice of the Post-Glitch world.
+**Translation:** N/A
+**Why:** To ensure all future content adheres to the strict aesthetic of technological ignorance and reverence.

--- a/src/Core/RuneAndRust.Application/Interfaces/IInputHandler.cs
+++ b/src/Core/RuneAndRust.Application/Interfaces/IInputHandler.cs
@@ -27,7 +27,6 @@ public record TakeCommand(string ItemName) : GameCommand;
 public record AttackCommand : GameCommand;
 public record SearchCommand(string? Target = null) : GameCommand;
 public record InvestigateCommand(string Target) : GameCommand;
-public record ExamineCommand(string Target) : GameCommand;
 public record TravelCommand(string? Destination = null) : GameCommand;
 public record EnterCommand(string? Location = null) : GameCommand;
 public record ExitCommand(string? Direction = null) : GameCommand;

--- a/src/Core/RuneAndRust.Application/Services/RoomInstantiator.cs
+++ b/src/Core/RuneAndRust.Application/Services/RoomInstantiator.cs
@@ -101,7 +101,7 @@ public class RoomInstantiator : IRoomInstantiator
                     baseTemplate, modifier, roomTags, random, roomFunction);
 
                 // Create room
-                var position = new Position(node.Coordinate.X, node.Coordinate.Y);
+                var position = new Position3D(node.Coordinate.X, node.Coordinate.Y, node.Coordinate.Z);
                 var room = new Room(name, description, position, biome);
 
                 // Propagate tags
@@ -130,8 +130,8 @@ public class RoomInstantiator : IRoomInstantiator
         name = template.ProcessName(placeholders);
         description = template.ProcessDescription(placeholders);
 
-        // Create room at node position (convert 3D to 2D for now)
-        var legacyPosition = new Position(node.Coordinate.X, node.Coordinate.Y);
+        // Create room at node position
+        var legacyPosition = new Position3D(node.Coordinate.X, node.Coordinate.Y, node.Coordinate.Z);
         var legacyRoom = new Room(name, description, legacyPosition, biome);
 
         // Propagate tags from template and node

--- a/src/Core/RuneAndRust.Domain/Entities/EntityTemplate.cs
+++ b/src/Core/RuneAndRust.Domain/Entities/EntityTemplate.cs
@@ -12,6 +12,7 @@ public class EntityTemplate : IEntity
     public Guid Id { get; private set; }
     public string EntityId { get; private set; }
     public string Name { get; private set; }
+    public string Description { get; private set; }
     public string FactionId { get; private set; }
     public Biome Biome { get; private set; }
     public int Cost { get; private set; }
@@ -26,12 +27,14 @@ public class EntityTemplate : IEntity
     {
         EntityId = null!;
         Name = null!;
+        Description = null!;
         FactionId = null!;
     } // For EF Core
 
     public EntityTemplate(
         string entityId,
         string name,
+        string description,
         string factionId,
         Biome biome,
         int cost,
@@ -42,6 +45,8 @@ public class EntityTemplate : IEntity
             throw new ArgumentException("Entity ID cannot be empty", nameof(entityId));
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("Name cannot be empty", nameof(name));
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ArgumentException("Description cannot be empty", nameof(description));
         if (string.IsNullOrWhiteSpace(factionId))
             throw new ArgumentException("Faction ID cannot be empty", nameof(factionId));
         if (cost < 1)
@@ -50,6 +55,7 @@ public class EntityTemplate : IEntity
         Id = Guid.NewGuid();
         EntityId = entityId;
         Name = name;
+        Description = description;
         FactionId = factionId;
         Biome = biome;
         Cost = cost;
@@ -96,8 +102,7 @@ public class EntityTemplate : IEntity
     /// </summary>
     public Monster CreateMonster()
     {
-        var description = $"A hostile {Name.ToLower()}.";
-        return new Monster(Name, description, BaseStats.MaxHealth, BaseStats);
+        return new Monster(Name, Description, BaseStats.MaxHealth, BaseStats);
     }
 
     /// <summary>
@@ -106,6 +111,7 @@ public class EntityTemplate : IEntity
     public static EntityTemplate CreateSwarm(
         string entityId,
         string name,
+        string description,
         string factionId,
         Biome biome,
         int cost,
@@ -114,7 +120,7 @@ public class EntityTemplate : IEntity
         if (cost > 5)
             throw new ArgumentOutOfRangeException(nameof(cost), "Swarm units should cost 1-5");
 
-        var template = new EntityTemplate(entityId, name, factionId, biome, cost, EntityRole.Swarm, stats);
+        var template = new EntityTemplate(entityId, name, description, factionId, biome, cost, EntityRole.Swarm, stats);
         template.AddTag("Swarm");
         return template;
     }
@@ -125,6 +131,7 @@ public class EntityTemplate : IEntity
     public static EntityTemplate CreateGrunt(
         string entityId,
         string name,
+        string description,
         string factionId,
         Biome biome,
         int cost,
@@ -134,7 +141,7 @@ public class EntityTemplate : IEntity
         if (role == EntityRole.Swarm || role == EntityRole.Elite || role == EntityRole.Boss)
             throw new ArgumentException("Use specific factory for Swarm, Elite, or Boss units", nameof(role));
 
-        var template = new EntityTemplate(entityId, name, factionId, biome, cost, role, stats);
+        var template = new EntityTemplate(entityId, name, description, factionId, biome, cost, role, stats);
         template.AddTag("Grunt");
         return template;
     }
@@ -145,6 +152,7 @@ public class EntityTemplate : IEntity
     public static EntityTemplate CreateElite(
         string entityId,
         string name,
+        string description,
         string factionId,
         Biome biome,
         int cost,
@@ -153,7 +161,7 @@ public class EntityTemplate : IEntity
         if (cost < 40)
             throw new ArgumentOutOfRangeException(nameof(cost), "Elite units should cost 40+");
 
-        var template = new EntityTemplate(entityId, name, factionId, biome, cost, EntityRole.Elite, stats);
+        var template = new EntityTemplate(entityId, name, description, factionId, biome, cost, EntityRole.Elite, stats);
         template.AddTag("Elite");
         return template;
     }
@@ -164,6 +172,7 @@ public class EntityTemplate : IEntity
     public static EntityTemplate CreateBoss(
         string entityId,
         string name,
+        string description,
         string factionId,
         Biome biome,
         int cost,
@@ -172,7 +181,7 @@ public class EntityTemplate : IEntity
         if (cost < 100)
             throw new ArgumentOutOfRangeException(nameof(cost), "Boss units should cost 100+");
 
-        var template = new EntityTemplate(entityId, name, factionId, biome, cost, EntityRole.Boss, stats);
+        var template = new EntityTemplate(entityId, name, description, factionId, biome, cost, EntityRole.Boss, stats);
         template.AddTag("Boss");
         return template;
     }

--- a/src/Core/RuneAndRust.Domain/Entities/GameSession.cs
+++ b/src/Core/RuneAndRust.Domain/Entities/GameSession.cs
@@ -34,6 +34,16 @@ public class GameSession : IEntity
     public Guid CurrentRoomId { get; private set; }
 
     /// <summary>
+    /// Gets the ID of the previous room the player was in.
+    /// </summary>
+    public Guid? PreviousRoomId { get; private set; }
+
+    /// <summary>
+    /// Gets the current turn count.
+    /// </summary>
+    public int TurnCount { get; private set; }
+
+    /// <summary>
     /// Gets the current state of the game (e.g., Playing, GameOver, Victory).
     /// </summary>
     public GameState State { get; private set; }
@@ -49,6 +59,7 @@ public class GameSession : IEntity
     public DateTime LastPlayedAt { get; private set; }
 
     private readonly HashSet<string> _revealedSolutionIds = [];
+    private readonly HashSet<Guid> _visitedRooms = [];
 
     public Room? CurrentRoom => Dungeon.GetRoom(CurrentRoomId);
     public IReadOnlySet<string> RevealedSolutions => _revealedSolutionIds;
@@ -183,6 +194,16 @@ public class GameSession : IEntity
     public void UpdateLastPlayed()
     {
         LastPlayedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Advances the game turn counter.
+    /// </summary>
+    public int AdvanceTurn()
+    {
+        TurnCount++;
+        UpdateLastPlayed();
+        return TurnCount;
     }
 
     /// <summary>

--- a/src/Core/RuneAndRust.Domain/Entities/Room.cs
+++ b/src/Core/RuneAndRust.Domain/Entities/Room.cs
@@ -28,7 +28,6 @@ public class Room : IEntity
     /// Gets the narrative description of this room shown to the player.
     /// </summary>
     public string Description { get; private set; }
-    public Position Position { get; private set; }
     public Biome Biome { get; private set; }
 
     /// <summary>
@@ -354,7 +353,7 @@ public class Room : IEntity
         Description = null!;
     }
 
-    public Room(string name, string description, Position position, Biome biome = Biome.Citadel)
+    public Room(string name, string description, Position3D position, Biome biome = Biome.Citadel)
     {
         Id = Guid.NewGuid();
         Name = name ?? throw new ArgumentNullException(nameof(name));

--- a/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/EntityTableSeeder.cs
+++ b/src/Infrastructure/RuneAndRust.Infrastructure/Persistence/Seeders/EntityTableSeeder.cs
@@ -46,46 +46,60 @@ public static class EntityTableSeeder
 
         // Swarm units (cost 1-5)
         var skeleton = EntityTemplate.CreateSwarm(
-            "skeleton_minion", "Skeleton Minion", factionId, Biome.Citadel,
+            "skeleton_minion", "Skeleton Minion",
+            "A clattering assembly of old bones, bound by malice and rusted wire. It moves with a jerky, puppet-like gait, seeking to share its death.",
+            factionId, Biome.Citadel,
             cost: 3, new Stats(15, 5, 2, 5));
         skeleton.AddTags(["Undead", "Brittle", "Melee"]);
         yield return skeleton;
 
         var ghostLight = EntityTemplate.CreateSwarm(
-            "ghost_light", "Ghost Light", factionId, Biome.Citadel,
+            "ghost_light", "Ghost Light",
+            "A flickering sphere of cold, pale fire that drifts through the dark. It smells of ozone and old graves, leading the foolish to their doom.",
+            factionId, Biome.Citadel,
             cost: 2, new Stats(8, 3, 0, 8));
         ghostLight.AddTags(["Undead", "Flying", "Glowing"]);
         yield return ghostLight;
 
         // Grunt units (cost 5-40)
         var skeletonWarrior = EntityTemplate.CreateGrunt(
-            "skeleton_warrior", "Skeleton Warrior", factionId, Biome.Citadel,
+            "skeleton_warrior", "Skeleton Warrior",
+            "This one wears scraps of ancient iron-skin and wields a blade jagged with rust. The empty sockets of its skull burn with a hateful, distant light.",
+            factionId, Biome.Citadel,
             cost: 10, EntityRole.Melee, new Stats(30, 10, 5, 6));
         skeletonWarrior.AddTags(["Undead", "Armed", "Melee"]);
         yield return skeletonWarrior;
 
         var skeletonArcher = EntityTemplate.CreateGrunt(
-            "skeleton_archer", "Skeleton Archer", factionId, Biome.Citadel,
+            "skeleton_archer", "Skeleton Archer",
+            "Its bow is strung with dried sinew, its arrows tipped with scrap-metal. It draws with the patience of the grave, the wood creaking like a coffin lid.",
+            factionId, Biome.Citadel,
             cost: 12, EntityRole.Ranged, new Stats(20, 12, 3, 8));
         skeletonArcher.AddTags(["Undead", "Armed", "Ranged"]);
         yield return skeletonArcher;
 
         var wight = EntityTemplate.CreateGrunt(
-            "wight", "Barrow Wight", factionId, Biome.Citadel,
+            "wight", "Barrow Wight",
+            "A bloating horror shrouded in grave-mold and tattered finery. The air around it grows impossibly cold, tasting of wet earth and stagnation.",
+            factionId, Biome.Citadel,
             cost: 25, EntityRole.Tank, new Stats(50, 12, 10, 10));
         wight.AddTags(["Undead", "Heavy", "Fearsome"]);
         yield return wight;
 
         // Elite unit (cost 40+)
         var deathKnight = EntityTemplate.CreateElite(
-            "death_knight", "Death Knight", factionId, Biome.Citadel,
+            "death_knight", "Death Knight",
+            "A towering figure encased in black iron-skin, etched with runes that hurt the eyes. Its blade hums with a deep, subsonic dread.",
+            factionId, Biome.Citadel,
             cost: 60, new Stats(80, 18, 15, 12));
         deathKnight.AddTags(["Undead", "Heavy", "Melee", "Commander"]);
         yield return deathKnight;
 
         // Boss unit (cost 100+)
         var lichLord = EntityTemplate.CreateBoss(
-            "lich_lord", "Lich Lord", factionId, Biome.Citadel,
+            "lich_lord", "Lich Lord",
+            "A withered husk floating on currents of necrotic wind. It whispers words that make the skin crawl, commanding the dead with gestures of its rot-blackened hands.",
+            factionId, Biome.Citadel,
             cost: 150, new Stats(120, 25, 12, 18));
         lichLord.AddTags(["Undead", "Magical", "Ranged", "Commander"]);
         yield return lichLord;
@@ -101,46 +115,60 @@ public static class EntityTableSeeder
 
         // Swarm units
         var rustMite = EntityTemplate.CreateSwarm(
-            "rust_mite", "Rust Mite", factionId, Biome.TheRoots,
+            "rust_mite", "Rust Mite",
+            "A thumb-sized horror of twitching legs and grinding mandibles. It feeds on the iron-bones of the world, leaving only red dust in its wake.",
+            factionId, Biome.TheRoots,
             cost: 2, new Stats(10, 4, 1, 4));
         rustMite.AddTags(["Mechanical", "Swarm", "Corrosive"]);
         yield return rustMite;
 
         var sporeCloud = EntityTemplate.CreateSwarm(
-            "spore_cloud", "Spore Cloud", factionId, Biome.TheRoots,
+            "spore_cloud", "Spore Cloud",
+            "A drifting haze of choking dust and viral life. To breathe it is to invite the garden into your lungs.",
+            factionId, Biome.TheRoots,
             cost: 3, new Stats(12, 3, 0, 6));
         sporeCloud.AddTags(["Organic", "Flying", "Toxic"]);
         yield return sporeCloud;
 
         // Grunt units
         var scavengerDrone = EntityTemplate.CreateGrunt(
-            "scavenger_drone", "Scavenger Drone", factionId, Biome.TheRoots,
+            "scavenger_drone", "Iron-Beak Scavenger",
+            "A small, flying machine with a single glass eye and grasping claws. It flits through the shadows like a bat made of scrap, hunting for fresh parts.",
+            factionId, Biome.TheRoots,
             cost: 15, EntityRole.Melee, new Stats(35, 12, 6, 8));
         scavengerDrone.AddTags(["Mechanical", "Salvager", "Melee"]);
         yield return scavengerDrone;
 
         var fungalStalker = EntityTemplate.CreateGrunt(
-            "fungal_stalker", "Fungal Stalker", factionId, Biome.TheRoots,
+            "fungal_stalker", "Fungal Stalker",
+            "Once human, now a walking hive of mushrooms and moss. It moves in silence, its footsteps muffled by the soft rot that covers its body.",
+            factionId, Biome.TheRoots,
             cost: 18, EntityRole.Melee, new Stats(40, 14, 5, 12));
         fungalStalker.AddTags(["Organic", "Stealthy", "Melee"]);
         yield return fungalStalker;
 
         var spitterNode = EntityTemplate.CreateGrunt(
-            "spitter_node", "Spitter Node", factionId, Biome.TheRoots,
+            "spitter_node", "Spittle-Mound",
+            "A pulsating growth rooted to the floor, resembling a boil on the world's skin. It heaves and coughs, launching globs of burning acid at intruders.",
+            factionId, Biome.TheRoots,
             cost: 20, EntityRole.Ranged, new Stats(30, 15, 4, 6));
         spitterNode.AddTags(["Organic", "Stationary", "Ranged", "Toxic"]);
         yield return spitterNode;
 
         // Elite unit
         var heavyLoader = EntityTemplate.CreateElite(
-            "heavy_loader", "Heavy Loader Bot", factionId, Biome.TheRoots,
+            "heavy_loader", "Titan-Lifter",
+            "A massive, hunched iron-walker, built for labor but repurposed for violence. Its hydraulic limbs hiss and groan as it crushes stone and bone alike.",
+            factionId, Biome.TheRoots,
             cost: 55, new Stats(90, 20, 18, 6));
         heavyLoader.AddTags(["Mechanical", "Heavy", "Melee", "Armored"]);
         yield return heavyLoader;
 
         // Boss unit
         var rootMother = EntityTemplate.CreateBoss(
-            "root_mother", "The Root Mother", factionId, Biome.TheRoots,
+            "root_mother", "The Root Mother",
+            "A colossal mass of tangled vines and weeping sores, fused into the very architecture. She screams with the voices of a thousand consumed souls.",
+            factionId, Biome.TheRoots,
             cost: 140, new Stats(150, 22, 15, 14));
         rootMother.AddTags(["Organic", "Massive", "Spawner", "Commander"]);
         yield return rootMother;
@@ -156,46 +184,60 @@ public static class EntityTableSeeder
 
         // Swarm units
         var fireImp = EntityTemplate.CreateSwarm(
-            "fire_imp", "Fire Imp", factionId, Biome.Muspelheim,
+            "fire_imp", "Fire Imp",
+            "A small, cackling spirit composed of soot and spark. It darts about like a stray ember, eager to set the world alight.",
+            factionId, Biome.Muspelheim,
             cost: 4, new Stats(12, 6, 2, 10));
         fireImp.AddTags(["Fire", "Small", "Ranged"]);
         yield return fireImp;
 
         var cinder = EntityTemplate.CreateSwarm(
-            "cinder", "Living Cinder", factionId, Biome.Muspelheim,
+            "cinder", "Living Cinder",
+            "A floating flake of burning ash, driven by a hateful will. It glows with a dull, throbbing heat, seeking fuel for its hunger.",
+            factionId, Biome.Muspelheim,
             cost: 3, new Stats(8, 5, 0, 8));
         cinder.AddTags(["Fire", "Flying", "Explosive"]);
         yield return cinder;
 
         // Grunt units
         var flameCultist = EntityTemplate.CreateGrunt(
-            "flame_cultist", "Flame Cultist", factionId, Biome.Muspelheim,
+            "flame_cultist", "Flame Cultist",
+            "A fanatic wrapped in scorched leathers, skin branded with the signs of the burning god. They chant prayers that smell of gasoline and sulfur.",
+            factionId, Biome.Muspelheim,
             cost: 12, EntityRole.Ranged, new Stats(25, 12, 4, 10));
         flameCultist.AddTags(["Human", "Fire", "Ranged"]);
         yield return flameCultist;
 
         var magmaElemental = EntityTemplate.CreateGrunt(
-            "magma_elemental", "Magma Elemental", factionId, Biome.Muspelheim,
+            "magma_elemental", "Magma Elemental",
+            "A lumbering construct of cooling slag and liquid fire. The heat radiating from it distorts the air, promising a slow, melting death.",
+            factionId, Biome.Muspelheim,
             cost: 30, EntityRole.Tank, new Stats(60, 15, 12, 6));
         magmaElemental.AddTags(["Elemental", "Fire", "Heavy", "Melee"]);
         yield return magmaElemental;
 
         var ashWraith = EntityTemplate.CreateGrunt(
-            "ash_wraith", "Ash Wraith", factionId, Biome.Muspelheim,
+            "ash_wraith", "Ash Wraith",
+            "A phantom shape formed from the smoke of funeral pyres. It chokes the light and silence, leaving only the taste of dust in the mouth.",
+            factionId, Biome.Muspelheim,
             cost: 22, EntityRole.Melee, new Stats(40, 16, 6, 12));
         ashWraith.AddTags(["Undead", "Fire", "Phasing", "Melee"]);
         yield return ashWraith;
 
         // Elite unit
         var flameWarden = EntityTemplate.CreateElite(
-            "flame_warden", "Flame Warden", factionId, Biome.Muspelheim,
+            "flame_warden", "Flame Warden",
+            "A champion of the cult, armored in plates of blackened steel that still hold the forge's heat. Their weapon is a torch of unquenchable chemical fire.",
+            factionId, Biome.Muspelheim,
             cost: 65, new Stats(85, 22, 14, 14));
         flameWarden.AddTags(["Human", "Fire", "Heavy", "Melee", "Commander"]);
         yield return flameWarden;
 
         // Boss unit
         var emberKing = EntityTemplate.CreateBoss(
-            "ember_king", "The Ember King", factionId, Biome.Muspelheim,
+            "ember_king", "The Ember King",
+            "A towering lord of ruin, wreathed in a crown of perpetual explosion. His laughter is the sound of a collapsing building, his gaze the flash of a bomb.",
+            factionId, Biome.Muspelheim,
             cost: 160, new Stats(140, 28, 18, 16));
         emberKing.AddTags(["Elemental", "Fire", "Massive", "Ranged", "Commander"]);
         yield return emberKing;
@@ -211,46 +253,60 @@ public static class EntityTableSeeder
 
         // Swarm units
         var iceSprite = EntityTemplate.CreateSwarm(
-            "ice_sprite", "Ice Sprite", factionId, Biome.Niflheim,
+            "ice_sprite", "Ice Sprite",
+            "A jagged shard of living crystal that flits on the freezing wind. Its touch burns with a cold so deep it stops the blood.",
+            factionId, Biome.Niflheim,
             cost: 3, new Stats(10, 4, 1, 12));
         iceSprite.AddTags(["Cold", "Small", "Flying", "Freezing"]);
         yield return iceSprite;
 
         var frostWorm = EntityTemplate.CreateSwarm(
-            "frost_worm", "Frost Worm", factionId, Biome.Niflheim,
+            "frost_worm", "Frost Worm",
+            "A pale, segmented thing that burrows through the frozen earth. It erupts from the ground with a spray of ice, mandibles clicking.",
+            factionId, Biome.Niflheim,
             cost: 4, new Stats(15, 5, 3, 4));
         frostWorm.AddTags(["Cold", "Burrowing", "Melee"]);
         yield return frostWorm;
 
         // Grunt units
         var frozenCorpse = EntityTemplate.CreateGrunt(
-            "frozen_corpse", "Frozen Corpse", factionId, Biome.Niflheim,
+            "frozen_corpse", "Frozen Corpse",
+            "A victim of the cold, perfectly preserved in a shell of blue rime. It shambles forward, stiff and unyielding, driven by a frozen hunger.",
+            factionId, Biome.Niflheim,
             cost: 14, EntityRole.Melee, new Stats(35, 10, 8, 5));
         frozenCorpse.AddTags(["Undead", "Cold", "Slow", "Melee"]);
         yield return frozenCorpse;
 
         var iceWraith = EntityTemplate.CreateGrunt(
-            "ice_wraith", "Ice Wraith", factionId, Biome.Niflheim,
+            "ice_wraith", "Ice Wraith",
+            "A translucent spirit that shimmers like heat-haze over snow. It passes through walls and armor alike, leaving frostbite on the soul.",
+            factionId, Biome.Niflheim,
             cost: 20, EntityRole.Melee, new Stats(30, 14, 4, 14));
         iceWraith.AddTags(["Undead", "Cold", "Phasing", "Melee", "Freezing"]);
         yield return iceWraith;
 
         var frostArcher = EntityTemplate.CreateGrunt(
-            "frost_archer", "Frost Archer", factionId, Biome.Niflheim,
+            "frost_archer", "Frost Archer",
+            "A hunter clad in furs stiff with ice. It waits in the blizzard, invisible until its shaft of black ice strikes home.",
+            factionId, Biome.Niflheim,
             cost: 16, EntityRole.Ranged, new Stats(25, 13, 5, 10));
         frostArcher.AddTags(["Human", "Cold", "Ranged", "Freezing"]);
         yield return frostArcher;
 
         // Elite unit
         var glacialBehemoth = EntityTemplate.CreateElite(
-            "glacial_behemoth", "Glacial Behemoth", factionId, Biome.Niflheim,
+            "glacial_behemoth", "Glacial Behemoth",
+            "A mountain of muscle and shaggy white fur, caked in glaciers. Its roar shakes the icicles from the ceiling and cracks the floor.",
+            factionId, Biome.Niflheim,
             cost: 70, new Stats(100, 18, 20, 6));
         glacialBehemoth.AddTags(["Elemental", "Cold", "Massive", "Melee", "Armored"]);
         yield return glacialBehemoth;
 
         // Boss unit
         var frostQueen = EntityTemplate.CreateBoss(
-            "frost_queen", "The Frost Queen", factionId, Biome.Niflheim,
+            "frost_queen", "The Frost Queen",
+            "An ancient sorceress whose heart froze centuries ago. She sits upon a throne of black ice, commanding the winter to scour the world clean.",
+            factionId, Biome.Niflheim,
             cost: 155, new Stats(130, 24, 16, 18));
         frostQueen.AddTags(["Undead", "Cold", "Magical", "Ranged", "Commander"]);
         yield return frostQueen;
@@ -266,46 +322,60 @@ public static class EntityTableSeeder
 
         // Swarm units
         var stoneSprite = EntityTemplate.CreateSwarm(
-            "stone_sprite", "Stone Sprite", factionId, Biome.Jotunheim,
+            "stone_sprite", "Stone Sprite",
+            "A tumbling rock that has forgotten it is stone. It mimics the shapes of life, grinding and clicking as it rolls toward you.",
+            factionId, Biome.Jotunheim,
             cost: 4, new Stats(18, 5, 5, 6));
         stoneSprite.AddTags(["Elemental", "Stone", "Small"]);
         yield return stoneSprite;
 
         var runeWisp = EntityTemplate.CreateSwarm(
-            "rune_wisp", "Rune Wisp", factionId, Biome.Jotunheim,
+            "rune_wisp", "Rune Wisp",
+            "A fragment of ancient writing that has peeled from the wall and taken flight. It pulses with a headache-inducing light.",
+            factionId, Biome.Jotunheim,
             cost: 5, new Stats(12, 7, 0, 14));
         runeWisp.AddTags(["Magical", "Flying", "Ranged"]);
         yield return runeWisp;
 
         // Grunt units
         var giantkin = EntityTemplate.CreateGrunt(
-            "giantkin", "Giantkin Warrior", factionId, Biome.Jotunheim,
+            "giantkin", "Giantkin Warrior",
+            "A towering brute with skin like granite and a voice like a rockslide. It wields a pillar of stone as a club.",
+            factionId, Biome.Jotunheim,
             cost: 25, EntityRole.Melee, new Stats(55, 16, 10, 8));
         giantkin.AddTags(["Giant", "Heavy", "Melee"]);
         yield return giantkin;
 
         var runeguard = EntityTemplate.CreateGrunt(
-            "runeguard", "Rune Guardian", factionId, Biome.Jotunheim,
+            "runeguard", "Rune Guardian",
+            "An empty suit of armor animated by the blue glow of inscribed runes. It stands vigil over secrets that should have remained forgotten.",
+            factionId, Biome.Jotunheim,
             cost: 30, EntityRole.Tank, new Stats(70, 12, 15, 10));
         runeguard.AddTags(["Construct", "Magical", "Armored", "Melee"]);
         yield return runeguard;
 
         var stormcaller = EntityTemplate.CreateGrunt(
-            "stormcaller", "Storm Caller", factionId, Biome.Jotunheim,
+            "stormcaller", "Storm Caller",
+            "A giant who speaks the language of thunder. Lightning crackles between its fingers, smelling of ozone and burnt hair.",
+            factionId, Biome.Jotunheim,
             cost: 28, EntityRole.Ranged, new Stats(40, 18, 6, 14));
         stormcaller.AddTags(["Giant", "Magical", "Ranged", "Lightning"]);
         yield return stormcaller;
 
         // Elite unit
         var jotunChampion = EntityTemplate.CreateElite(
-            "jotun_champion", "Jotun Champion", factionId, Biome.Jotunheim,
+            "jotun_champion", "Jotun Champion",
+            "A lord among the giantkin, clad in the bones of dragons. Each step it takes is an earthquake, each blow a catastrophe.",
+            factionId, Biome.Jotunheim,
             cost: 80, new Stats(120, 24, 18, 10));
         jotunChampion.AddTags(["Giant", "Heavy", "Melee", "Commander"]);
         yield return jotunChampion;
 
         // Boss unit
         var titanAwakened = EntityTemplate.CreateBoss(
-            "titan_awakened", "Awakened Titan", factionId, Biome.Jotunheim,
+            "titan_awakened", "Awakened Titan",
+            "A god of the old world, shaken from its slumber. It is less a creature and more a walking mountain, intent on crushing the insects that woke it.",
+            factionId, Biome.Jotunheim,
             cost: 200, new Stats(200, 35, 25, 12));
         titanAwakened.AddTags(["Giant", "Massive", "Ancient", "Commander"]);
         yield return titanAwakened;

--- a/tests/RuneAndRust.Application.UnitTests/Services/DungeonGeneratorTests.cs
+++ b/tests/RuneAndRust.Application.UnitTests/Services/DungeonGeneratorTests.cs
@@ -48,13 +48,13 @@ public class DungeonGeneratorTests
         // Create minimal entity templates
         var entityTemplates = new List<EntityTemplate>
         {
-            EntityTemplate.CreateSwarm("skeleton", "Skeleton", "undead_legion", Biome.Citadel, 3,
+            EntityTemplate.CreateSwarm("skeleton", "Skeleton", "A test skeleton.", "undead_legion", Biome.Citadel, 3,
                 new Stats(15, 5, 2, 5)),
-            EntityTemplate.CreateGrunt("warrior", "Skeleton Warrior", "undead_legion", Biome.Citadel, 10,
+            EntityTemplate.CreateGrunt("warrior", "Skeleton Warrior", "A test warrior.", "undead_legion", Biome.Citadel, 10,
                 EntityRole.Melee, new Stats(30, 10, 5, 6)),
-            EntityTemplate.CreateElite("knight", "Death Knight", "undead_legion", Biome.Citadel, 50,
+            EntityTemplate.CreateElite("knight", "Death Knight", "A test knight.", "undead_legion", Biome.Citadel, 50,
                 new Stats(80, 18, 15, 12)),
-            EntityTemplate.CreateBoss("lich", "Lich Lord", "undead_legion", Biome.Citadel, 100,
+            EntityTemplate.CreateBoss("lich", "Lich Lord", "A test boss.", "undead_legion", Biome.Citadel, 100,
                 new Stats(120, 25, 12, 18))
         };
 

--- a/tests/RuneAndRust.Domain.UnitTests/Entities/RoomFeatureTests.cs
+++ b/tests/RuneAndRust.Domain.UnitTests/Entities/RoomFeatureTests.cs
@@ -14,7 +14,7 @@ public class RoomFeatureTests
     [SetUp]
     public void Setup()
     {
-        _room = new Room("Test Room", "A test room", new Position(0, 0), Biome.Citadel);
+        _room = new Room("Test Room", "A test room", new Position3D(0, 0, 0), Biome.Citadel);
     }
 
     [Test]

--- a/tests/RuneAndRust.Domain.UnitTests/Entities/RoomHiddenElementsTests.cs
+++ b/tests/RuneAndRust.Domain.UnitTests/Entities/RoomHiddenElementsTests.cs
@@ -13,7 +13,7 @@ public class RoomHiddenElementsTests
     [SetUp]
     public void SetUp()
     {
-        _room = new Room("Test Room", "A test room", new Position(0, 0), Biome.Citadel);
+        _room = new Room("Test Room", "A test room", new Position3D(0, 0, 0), Biome.Citadel);
     }
 
     [Test]
@@ -153,8 +153,8 @@ public class RoomHiddenElementsTests
     public void Room_WithBiome_StoresBiomeCorrectly()
     {
         // Arrange & Act
-        var rootsRoom = new Room("Root Chamber", "A fungal chamber", new Position(0, 0), Biome.TheRoots);
-        var fireRoom = new Room("Magma Forge", "A volcanic forge", new Position(1, 0), Biome.Muspelheim);
+        var rootsRoom = new Room("Root Chamber", "A fungal chamber", new Position3D(0, 0, 0), Biome.TheRoots);
+        var fireRoom = new Room("Magma Forge", "A volcanic forge", new Position3D(1, 0, 0), Biome.Muspelheim);
 
         // Assert
         rootsRoom.Biome.Should().Be(Biome.TheRoots);
@@ -165,7 +165,7 @@ public class RoomHiddenElementsTests
     public void Room_DefaultBiome_IsCitadel()
     {
         // Arrange & Act
-        var room = new Room("Standard Room", "A standard room", new Position(0, 0));
+        var room = new Room("Standard Room", "A standard room", new Position3D(0, 0, 0));
 
         // Assert
         room.Biome.Should().Be(Biome.Citadel);


### PR DESCRIPTION
This PR implements "The Narrator" agent persona, focusing on generating immersive "Post-Glitch" flavor text.

Key Changes:
1.  **Narrator Content:**
    -   Rewrote all entity descriptions in `EntityTableSeeder.cs` to adhere to the "Ignorance is Aesthetic" philosophy.
    -   Renamed modern/tech entities (e.g., "Scavenger Drone" -> "Iron-Beak Scavenger").
    -   Added `Description` support to `EntityTemplate` to enable this content.

2.  **Build Fixes (Necessary for Verification):**
    -   Fixed `Room.cs` compilation error where `Position` (2D) and `Position` (3D) properties conflicted. Standardized on `Position3D`.
    -   Updated `RoomInstantiator.cs` to use `Position3D` when creating rooms.
    -   Fixed `GameSession.cs` compilation errors by adding missing `TurnCount`, `PreviousRoomId`, and `_visitedRooms` properties.
    -   Removed duplicate `ExamineCommand` in `IInputHandler.cs`.

These "scope creep" changes were necessary to compile the project and verify the content updates, as the codebase had pre-existing build failures.

---
*PR created automatically by Jules for task [747828253193999284](https://jules.google.com/task/747828253193999284) started by @southpawriter02*